### PR TITLE
Update epdif.h

### DIFF
--- a/Arduino/epd1in54_V2/epdif.h
+++ b/Arduino/epd1in54_V2/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition
 #define RST_PIN         8


### PR DESCRIPTION
Correct spelling of include file for all OS (not only Windows, which is not care about upper/lower case)